### PR TITLE
Avoid needless copies by changing http::Request<Vec<u8>> to http::Request<Bytes>

### DIFF
--- a/matrix_sdk/src/http_client.rs
+++ b/matrix_sdk/src/http_client.rs
@@ -30,7 +30,9 @@ use matrix_sdk_common::{
     FromHttpResponseError, IncomingResponse, SendAccessToken,
 };
 
-use crate::{error::HttpError, Bytes, ClientConfig, OutgoingRequest, RequestConfig, Session};
+use crate::{
+    error::HttpError, Bytes, BytesMut, ClientConfig, OutgoingRequest, RequestConfig, Session,
+};
 
 /// Abstraction around the http layer. The allows implementors to use different
 /// http libraries.
@@ -50,6 +52,7 @@ pub trait HttpSend: AsyncTraitDeps {
     /// # Examples
     ///
     /// ```
+    /// use bytes::Bytes;
     /// use std::convert::TryFrom;
     /// use matrix_sdk::{HttpSend, async_trait, HttpError, RequestConfig, Bytes};
     ///
@@ -70,7 +73,7 @@ pub trait HttpSend: AsyncTraitDeps {
     /// impl HttpSend for Client {
     ///     async fn send_request(
     ///         &self,
-    ///         request: http::Request<Vec<u8>>,
+    ///         request: http::Request<Bytes>,
     ///         config: RequestConfig,
     ///     ) -> Result<http::Response<Bytes>, HttpError> {
     ///         Ok(self
@@ -85,7 +88,7 @@ pub trait HttpSend: AsyncTraitDeps {
     /// ```
     async fn send_request(
         &self,
-        request: http::Request<Vec<u8>>,
+        request: http::Request<Bytes>,
         config: RequestConfig,
     ) -> Result<http::Response<Bytes>, HttpError>;
 }
@@ -121,7 +124,9 @@ impl HttpClient {
                 _ => return Err(HttpError::NotClientRequest),
             };
 
-            request.try_into_http_request(&self.homeserver.to_string(), access_token)?
+            request
+                .try_into_http_request::<BytesMut>(&self.homeserver.to_string(), access_token)?
+                .map(|body| body.freeze())
         };
 
         let config = match config {
@@ -229,7 +234,7 @@ async fn response_to_http_response(
 #[cfg(any(target_arch = "wasm32"))]
 async fn send_request(
     client: &Client,
-    request: http::Request<Vec<u8>>,
+    request: http::Request<Bytes>,
     _: RequestConfig,
 ) -> Result<http::Response<Bytes>, HttpError> {
     let request = reqwest::Request::try_from(request)?;
@@ -241,7 +246,7 @@ async fn send_request(
 #[cfg(all(not(target_arch = "wasm32")))]
 async fn send_request(
     client: &Client,
-    request: http::Request<Vec<u8>>,
+    request: http::Request<Bytes>,
     config: RequestConfig,
 ) -> Result<http::Response<Bytes>, HttpError> {
     let mut backoff = ExponentialBackoff::default();
@@ -303,7 +308,7 @@ async fn send_request(
 impl HttpSend for Client {
     async fn send_request(
         &self,
-        request: http::Request<Vec<u8>>,
+        request: http::Request<Bytes>,
         config: RequestConfig,
     ) -> Result<http::Response<Bytes>, HttpError> {
         send_request(&self, request, config).await

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -74,7 +74,7 @@ pub use matrix_sdk_base::{
     Session, StateChanges, StoreError,
 };
 
-pub use bytes::Bytes;
+pub use bytes::{Bytes, BytesMut};
 pub use matrix_sdk_common::*;
 pub use reqwest;
 


### PR DESCRIPTION
Small addition to https://github.com/matrix-org/matrix-rust-sdk/pull/215